### PR TITLE
axi_err_unit_wrap: Support atomics

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -10,6 +10,7 @@ package:
 dependencies:
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.29.0 }
   register_interface: { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.1 }
+  axi:                { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.1 }
 
 sources:
   # Level 1

--- a/src/axi_err_unit_wrap.sv
+++ b/src/axi_err_unit_wrap.sv
@@ -31,7 +31,7 @@ module axi_err_unit_wrap #(
   output reg_rsp_t reg_rsp_o
 );
 
-  logic [2**IdWidth-1:0] write_req_hs_valid, write_rsp_hs_valid, read_req_hs_valid, read_rsp_hs_valid;
+  logic [2**IdWidth-1:0] write_req_hs_valid, write_rsp_hs_valid, read_req_hs_valid, read_rsp_hs_valid, amo_req_hs_valid;
   logic [UserErrBits+2-1:0] write_err, read_err;
   reg_req_t [1:0] reg_req_internal;
   reg_rsp_t [1:0] reg_rsp_internal;
@@ -41,6 +41,7 @@ module axi_err_unit_wrap #(
     assign write_rsp_hs_valid[i] = axi_rsp_i.b_valid  & axi_req_i.b_ready  & (axi_rsp_i.b.id == i);
     assign read_req_hs_valid[i]  = axi_req_i.ar_valid & axi_rsp_i.ar_ready & (axi_req_i.ar.id == i);
     assign read_rsp_hs_valid[i]  = axi_rsp_i.r_valid  & axi_req_i.r_ready  & (axi_rsp_i.r.id == i);
+    assign amo_req_hs_valid[i]   = write_req_hs_valid[i] & (axi_req_i.aw.atop != axi_pkg::ATOP_NONE);
   end
 
   assign write_err[1:0] = axi_rsp_i.b.resp[1] ? axi_rsp_i.b.resp : '0;
@@ -71,6 +72,7 @@ module axi_err_unit_wrap #(
     .ErrBits        (2 + UserErrBits),
     .NumOutstanding (NumOutstanding),
     .NumStoredErrors(NumStoredErrors),
+    .NumReqPorts    (1),
     .NumChannels    (2**IdWidth),
     .DropOldest     (DropOldest),
     .reg_req_t      (reg_req_t),
@@ -99,6 +101,7 @@ module axi_err_unit_wrap #(
     .ErrBits        (2 + UserErrBits),
     .NumOutstanding (NumOutstanding),
     .NumStoredErrors(NumStoredErrors),
+    .NumReqPorts    (2),
     .NumChannels    (2**IdWidth),
     .DropOldest     (DropOldest),
     .reg_req_t      (reg_req_t),
@@ -109,9 +112,9 @@ module axi_err_unit_wrap #(
     .rst_ni,
     .testmode_i,
 
-    .req_hs_valid_i   ( read_req_hs_valid  ),
-    .req_addr_i       ( axi_req_i.ar.addr  ),
-    .req_meta_i       ( axi_req_i.ar.id    ),
+    .req_hs_valid_i   ( {amo_req_hs_valid, read_req_hs_valid} ),
+    .req_addr_i       ( {axi_req_i.aw.addr, axi_req_i.ar.addr} ),
+    .req_meta_i       ( {axi_req_i.aw.id, axi_req_i.ar.id} ),
     .rsp_hs_valid_i   ( read_rsp_hs_valid  ),
     .rsp_burst_last_i ( read_rsp_hs_valid & {2**IdWidth{axi_rsp_i.r.last}} ),
     .rsp_err_i        ( read_err ),

--- a/src/bus_err_unit.sv
+++ b/src/bus_err_unit.sv
@@ -11,26 +11,27 @@ module bus_err_unit #(
   parameter int unsigned ErrBits         = 3,
   parameter int unsigned NumOutstanding  = 4,
   parameter int unsigned NumStoredErrors = 4,
+  parameter int unsigned NumReqPorts     = 1,
   parameter int unsigned NumChannels     = 1, // Channels are one-hot!
   parameter bit          DropOldest      = 1'b0,
   parameter type         reg_req_t       = logic,
   parameter type         reg_rsp_t       = logic
 ) (
-  input  logic                     clk_i,
-  input  logic                     rst_ni,
-  input  logic                     testmode_i,
-  
-  input  logic [  NumChannels-1:0] req_hs_valid_i,
-  input  logic [    AddrWidth-1:0] req_addr_i,
-  input  logic [MetaDataWidth-1:0] req_meta_i,
-  input  logic [  NumChannels-1:0] rsp_hs_valid_i,
-  input  logic [  NumChannels-1:0] rsp_burst_last_i,
-  input  logic [      ErrBits-1:0] rsp_err_i,
+  input  logic                                      clk_i,
+  input  logic                                      rst_ni,
+  input  logic                                      testmode_i,
 
-  output logic                     err_irq_o,
+  input  logic [NumReqPorts-1:0][  NumChannels-1:0] req_hs_valid_i,
+  input  logic [NumReqPorts-1:0][    AddrWidth-1:0] req_addr_i,
+  input  logic [NumReqPorts-1:0][MetaDataWidth-1:0] req_meta_i,
+  input  logic                  [  NumChannels-1:0] rsp_hs_valid_i,
+  input  logic                  [  NumChannels-1:0] rsp_burst_last_i,
+  input  logic                  [      ErrBits-1:0] rsp_err_i,
 
-  input  reg_req_t                 reg_req_i,
-  output reg_rsp_t                 reg_rsp_o
+  output logic                                      err_irq_o,
+
+  input  reg_req_t                                  reg_req_i,
+  output reg_rsp_t                                  reg_rsp_o
 
 );
 
@@ -80,6 +81,7 @@ module bus_err_unit #(
     .ErrBits        ( ErrBits         ),
     .NumOutstanding ( NumOutstanding  ),
     .NumStoredErrors( NumStoredErrors ),
+    .NumReqPorts    ( NumReqPorts     ),
     .NumChannels    ( NumChannels     ),
     .DropOldest     ( DropOldest      )
   ) i_err_unit_bare (


### PR DESCRIPTION
Support atomics by pushing atomic addresses (from the `AW`) channel onto the read queue.
- [x] Test