### PR TITLE
Fix register content on empty error FIFO

### DIFF
--- a/src/bus_err_unit_bare.sv
+++ b/src/bus_err_unit_bare.sv
@@ -147,9 +147,9 @@ module bus_err_unit_bare #(
     .pop_i     ( pop_err_fifo   )
   );
 
-  assign err_code_o = read_err_addr.err;
-  assign err_addr_o = read_err_addr.addr;
-  assign err_meta_o = read_err_addr.meta;
+  assign err_code_o = err_fifo_empty ? '0 : read_err_addr.err;
+  assign err_addr_o = err_fifo_empty ? '0 : read_err_addr.addr;
+  assign err_meta_o = err_fifo_empty ? '0 : read_err_addr.meta;
 
   assign err_fifo_overflow_o = bus_unit_full;
 


### PR DESCRIPTION
The current implementation of the `bus_err_unit` has the following bug:
If `NumOutstanding` or more errors were pushed to the error FIFO, the error unit will not appear to pop anymore, independent on how often the error code register is read. This is because in the current implementation of the `bus_err_unit`, the memory-mapped registers will always get the information from an element in the error FIFO, even if the queue is empty and the information is not valid.

An existing work-around is to check if the interrupt signal is still active before reading the error register to see if the information is valid.

A proposed fix is to set the signals provided to the memory-mapped registers (or at least the error code signal) to zero if the error FIFO is empty.